### PR TITLE
2 kleine correcties

### DIFF
--- a/cursus/toetsingsprocedures.tex
+++ b/cursus/toetsingsprocedures.tex
@@ -279,7 +279,7 @@ Het codevoorbeeld hieronder is de uitwerking van Voorbeeld~\ref{ex:hypothesetoet
     \[ g = \mu - z \times \frac{\sigma}{\sqrt{n}} \]
     en dus
     
-    \[ g = 27 - 1,645 \times \sqrt{\frac{\sigma}{n}} \]
+    \[ g = 27 - 1,645 \times \sqrt{\frac{55}{50}} \]
     \[ g =  25,27470944 \]
     
     We vinden dus dat $\overline{x} < g$ komen tot hetzelfde besluit, nl.~dat we $H_{0}$ kunnen verwerpen.
@@ -307,7 +307,7 @@ Het codevoorbeeld hieronder is de uitwerking van Voorbeeld~\ref{ex:hypothesetoet
     
     \item Kritiek gebied.
     
-    We vinden dat $\overline{x}$ in het kritieke gebied ligt (want $\overline{x} = 23 < g_1 = 23,25$), dus mogen we $H_{0}$ verwerpen.
+    We vinden dat $\overline{x}$ in het kritieke gebied ligt (want $\overline{x} = 23 < g_1 = 23,28$), dus mogen we $H_{0}$ verwerpen.
     
   \end{enumerate}
 \end{example}


### PR DESCRIPTION
1. g was fout ingevuld. de vierkantswortel was over de hele breuk, en dat is incorrect. Ik vermoed dat het de bedoeling was om de waardes in te vullen en dan mag de wortel wel over de hele breuk staan aangezien sigma = wortel 55
2. g1 fout overgenomen. Het moet 23,28 zijn ipv 23,25