### PR TITLE
Fout oplossen bij steekproefonderzoek

### DIFF
--- a/cursus/steekproefonderzoek.tex
+++ b/cursus/steekproefonderzoek.tex
@@ -494,7 +494,7 @@ Deze uitdrukking hangt van $\mu$ af maar we weten wel dat deze standaardnormaal 
 
 Hieruit halen we dat $\alpha = 0,05$. Door het toepassen van de symmetrieregel weten we dus dat we volgende term moeten berekenen:
 
-\[ P( Z < z) = 0,025 \]
+\[ P( Z < z) = 1 - 0,025 \]
 
 Kijken we in de Z-tabel dan vinden we voor de rechterstaartkans $0,025$ de z-score van $1,96$.
 


### PR DESCRIPTION
Op lijn 497 heb ik P(Z<z) = 0.025 vervangen door P(Z<z) = 1 - 0.025